### PR TITLE
Fix vars path and pull in upstream updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on: [
   pull_request
 ]
 
+env:
+  PIP_CACHE_DIR: ~/.cache/pip
+  PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,7 +25,7 @@ jobs:
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
-          path: ~/.cache/pip
+          path: ${{ env.PIP_CACHE_DIR }}
           key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}"
           restore-keys: |
@@ -31,7 +35,7 @@ jobs:
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
-          path: ~/.cache/pre-commit
+          path: ${{ env.PRE_COMMIT_CACHE_DIR }}
           key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Install dependencies

--- a/.mdl_config.json
+++ b/.mdl_config.json
@@ -3,5 +3,8 @@
     "code_blocks": false,
     "tables": false
   },
+  "MD024": {
+    "allow_different_nesting": true
+  },
   "default": true
 }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,8 +13,9 @@ galaxy_info:
       versions:
         - stretch
         - buster
-        # Kali linux isn't an option here, but it is based on Debian
-        # testing
+        # Kali linux isn't an option here, but it is based on
+        # Debian Testing:
+        # https://www.kali.org/docs/policy/kali-linux-relationship-with-debian
         - bullseye
     - name: Fedora
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,9 @@ galaxy_info:
       versions:
         - stretch
         - buster
+        # Kali linux isn't an option here, but it is based on Debian
+        # testing
+        - bullseye
     - name: Fedora
       versions:
         - 29
@@ -21,6 +24,10 @@ galaxy_info:
         # can't use Fedora 30.
         # - 30
         - 31
+    - name: Ubuntu
+      versions:
+        - bionic
+        - xenial
   galaxy_tags:
     - skeleton
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -27,6 +27,13 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
+  - name: debian11_systemd
+    image: cisagov/docker-debian11-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
   - name: kali_systemd
     image: cisagov/docker-kali-ansible:latest
     privileged: yes

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     image: debian:buster-slim
   - name: debian11
     image: debian:bullseye-slim
-  - name: kalilinux
+  - name: kali
     image: kalilinux/kali-rolling
   - name: fedora29
     image: fedora:29

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,7 +15,7 @@ platforms:
   - name: debian11
     image: debian:bullseye-slim
   - name: kalilinux
-    image: kalilinux/kali-linux-docker
+    image: kalilinux/kali-rolling
   - name: fedora29
     image: fedora:29
   # Ansible currently insists on installing python2-dnf, which does

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: debian:stretch-slim
   - name: debian10
     image: debian:buster-slim
+  - name: debian11
+    image: debian:bullseye-slim
+  - name: kalilinux
+    image: kalilinux/kali-linux-docker
   - name: fedora29
     image: fedora:29
   # Ansible currently insists on installing python2-dnf, which does
@@ -21,6 +25,10 @@ platforms:
   #   image: fedora:30
   - name: fedora31
     image: fedora:31
+  - name: ubuntu16
+    image: ubuntu:xenial
+  - name: ubuntu18
+    image: ubuntu:bionic
 provisioner:
   name: ansible
   lint:

--- a/tasks/install_common.yml
+++ b/tasks/install_common.yml
@@ -12,3 +12,7 @@
     remote_src: yes
     extra_opts:
       - "--strip-components=1"
+  # The contents of the tarball are modified in some cases by the
+  # Makefile it contains, so we need to noqa this task to pass
+  # idempotence testing.
+  changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
         # Debian setup tasks file.
         - install_Debian.yml
       paths:
-        - tasks
+        - "{{ role_path }}/tasks"
 
 - name: Enable Amazon EFS mount watchdog service
   service:


### PR DESCRIPTION
## 🗣 Description

This pull request pulls in upstream changes from [cisagov/skeleton-ansible-role](https://github.com/cisagov/skeleton-ansible-role) and fixes a path issue that could cause this role to pick up the vars files from a parent role that is using it.  I ran into this specific error case today with [cisagov/ansible-role-openvpn](https;//github.com/cisagov/ansible-role-openvpn), which has [cisagov/ansible-role-pip](https://github.com/cisagov/ansible-role-pip) as a dependency.

## 💭 Motivation and Context

The main motivation is to fix the path issue, since it can cause problems if another role has this one as a dependency.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
