### PR TITLE
Revert back to the official repo (aws/efs-utils)

### DIFF
--- a/tasks/install_common.yml
+++ b/tasks/install_common.yml
@@ -6,8 +6,7 @@
 
 - name: Download a tarball of the aws/efs-utils repository
   unarchive:
-    # s/jsf9k/aws once aws/efs-utils#48 is merged
-    src: https://github.com/jsf9k/efs-utils/tarball/master
+    src: https://github.com/aws/efs-utils/tarball/master
     dest: /tmp/efs-utils
     remote_src: yes
     extra_opts:


### PR DESCRIPTION
## 🗣 Description

This pull request reverts back to using [the official repo](https://github.com/aws/efs-utils), instead of [my fork](https://github.com/jsf9k/efs-utils).

## 💭 Motivation and Context

The use of [jsf9k/efs-utils](https://github.com/jsf9k/efs-utils) was only temporary.  Now that aws/efs-utils#48 has been merged we can revert to using the official repo.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
