### PR TITLE
Handle Kali case explicitly and pull in upstream changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
-      - name: Install pre-commit hooks
+      - name: Set up pre-commit hook environments
         run: pre-commit install-hooks
       - name: Run pre-commit on all files
         run: pre-commit run --all-files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,5 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
+      - name: Install pre-commit hooks
+        run: pre-commit install-hooks
       - name: Run pre-commit on all files
         run: pre-commit run --all-files

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .mypy_cache
-__pycache__
 .python-version
+__pycache__

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.20.0
+    rev: v1.21.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.4
+    rev: v2.1.0
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -76,19 +76,19 @@ repos:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.12.0
+    rev: v1.27.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate_no_variables
+      - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+    rev: 2.0.2
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.761
+    rev: v0.770
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.27.0
+    rev: v1.29.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -85,7 +85,7 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.2
+    rev: 2.0.4
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/tasks/install_Kali_GNU_Linux.yml
+++ b/tasks/install_Kali_GNU_Linux.yml
@@ -1,0 +1,3 @@
+---
+- name: Use Debian tasks for Kali
+  include_tasks: install_Debian.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,13 +6,11 @@
   vars:
     params:
       files:
-        - install_{{ ansible_distribution }}.yml
-        - install_{{ ansible_os_family }}.yml
-        # The OS family and distribution for Kali is "Kali GNU/Linux",
-        # which is not an allowable file name in Linux due to the
-        # slash.  We will allow Kali to fall through and use the
-        # Debian setup tasks file.
-        - install_Debian.yml
+        # Add regex_replace() filters to remove spaces and
+        # slashes. This allows the OS family/distribution for Kali,
+        # "Kali GNU/Linux", to be easily mapped to a vars file.
+        - install_{{ ansible_distribution | regex_replace('[ /]', '_') }}.yml
+        - install_{{ ansible_os_family | regex_replace('[ /]', '_') }}.yml
       paths:
         - "{{ role_path }}/tasks"
 


### PR DESCRIPTION
## 🗣 Description

In this pull request I modify the code to handle the Kali case explicitly.  I also pull in upstream changes from [cisagov/skeleton-ansible-role](https://github.com/cisagov/skeleton-ansible-role).

## 💭 Motivation and Context

The `ansible_distribution` and `ansible_os_family` Ansible facts for Kali Linux contain forward slashes.  The latter, in particular, are not allowed in Linux filenames.  In previous code I had handled the Kali case by setting the default vars or tasks file to be the Debian one.  @mcdonnnj took a different tack, where he filtered those facts through a `regex_replace()` filter and thus handled the Kali case explicitly.  This is a cleaner and more explicit way of doing things, and is therefore preferred.

@mcdonnnj also pointed out to me that Kali Linux does not always use the Debian packages directly, but in some cases hosts their own versions of packages that may install other dependencies or differ in other ways.  Therefore there is no guarantee that setting the default vars or tasks file to the Debian one and letting Kali "fall through" to Debian (a la a `switch` statement) will always be the correct thing to do.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
