### PR TITLE
Ignore ansible-lint E208 for unarchive task

### DIFF
--- a/tasks/install_common.yml
+++ b/tasks/install_common.yml
@@ -6,11 +6,12 @@
     state: directory
 
 - name: Download a tarball of the aws/efs-utils repository
-  unarchive:
+  # ansible-lint E208 gives an error if we don't specify the mode,
+  # but we definitely don't want to do that here since it will
+  # override the permissions on the files in the archive.
+  unarchive: # noqa 208
     src: https://github.com/aws/efs-utils/tarball/master
     dest: /tmp/efs-utils
-    # Mode here must match mode above or else idempotence fails
-    mode: 0755
     remote_src: yes
     extra_opts:
       - "--strip-components=1"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR removes a `mode` option that was added in #7 and replaces it with an `ansible-lint` `noqa` comment to ignore the `E208` check in the case of an unarchive task.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
In #7, I added several `mode` options to satisfy `ansible-lint`, however @mcdonnnj rightly pointed out that in the past, we have preferred to ignore [`ansible-lint E208`](https://ansible-lint.readthedocs.io/en/latest/default_rules.html#file-permissions-unset-or-incorrect) on unarchive tasks- for example [here](https://github.com/cisagov/ansible-role-cyhy-commander/blob/develop/tasks/main.yml#L27-L36).

Thanks also to @jsf9k for mentioning this to me as well.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
All automated tests pass.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
