### PR TITLE
Add option to create EFS users group

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ None.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
+| create_efs_users_group | Whether or not to create a group for EFS share users. | `true` | No |
+| efs_users_gid | The GID to assign the group for EFS share users. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
+| efs_users_group | The name of group to be created for EFS share users. | `efs_users` | No |
+<!--
 | required_variable | Describe its purpose. | n/a | Yes |
 -->
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Whether or not to create a group for EFS users
+create_efs_users_group: true
+
+# The name of the group to be created for EFS users
+efs_users_group: efs_users

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
   # Kali Linux, so it makes sense to force the installation of Ansible
   # 2.10 or newer.
   min_ansible_version: 2.10
+  namespace: cisagov
   platforms:
     - name: Amazon
       versions:

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -34,3 +34,8 @@ def test_packages(host):
 def test_services(host, service):
     """Test that the expected services were enabled."""
     assert host.service(service).is_enabled
+
+
+def test_efs_users_group(host):
+    """Test that the expected group was created."""
+    assert host.group("efs_users").exists

--- a/tasks/install_Amazon.yml
+++ b/tasks/install_Amazon.yml
@@ -1,5 +1,5 @@
 ---
 - name: Install amazon-efs-utils
-  package:
+  ansible.builtin.package:
     name:
       - amazon-efs-utils

--- a/tasks/install_Debian.yml
+++ b/tasks/install_Debian.yml
@@ -1,26 +1,26 @@
 ---
 - name: Install amazon-efs-utils prerequisites
-  package:
+  ansible.builtin.package:
     name:
       - make
       - binutils
 
 - name: Load tasks file with common install tasks
-  include: install_common.yml
+  ansible.builtin.include: install_common.yml
 
 - name: Build deb packages from the aws/efs-utils code
-  command: ./build-deb.sh
+  ansible.builtin.command: ./build-deb.sh
   args:
     chdir: /tmp/efs-utils
     creates: /tmp/efs-utils/build
 
 - name: Find all aws/efs-utils deb packages that were built
-  find:
+  ansible.builtin.find:
     paths: /tmp/efs-utils/build
     patterns: "amazon-efs-utils*.deb"
   register: find_result
 
 - name: Install aws/efs-utils deb packages
-  apt:
+  ansible.builtin.apt:
     deb: "{{ item }}"
   loop: "{{ find_result | json_query('files[*].path') }}"

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -1,15 +1,15 @@
 ---
 - name: Install amazon-efs-utils prerequisites
-  package:
+  ansible.builtin.package:
     name:
       - make
       - rpm-build
 
 - name: Load tasks file with common install tasks
-  include: install_common.yml
+  ansible.builtin.include: install_common.yml
 
 - name: Build rpms from the aws/efs-utils code
-  make:
+  ansible.builtin.make:
     chdir: /tmp/efs-utils
     target: rpm
   # This task always runs and recreates the rpms, no matter what.
@@ -18,13 +18,13 @@
     - molecule-idempotence-notest
 
 - name: Find all aws/efs-utils rpms that were built
-  find:
+  ansible.builtin.find:
     paths: /tmp/efs-utils/build
     patterns: "amazon-efs-utils*.rpm"
   register: find_result
 
 - name: Install aws/efs-utils rpms
-  yum:
+  ansible.builtin.yum:
     disable_gpg_check: yes
     name: "{{ item }}"
   loop: "{{ find_result | json_query('files[*].path') }}"

--- a/tasks/install_common.yml
+++ b/tasks/install_common.yml
@@ -1,12 +1,12 @@
 ---
 - name: Create the /tmp/efs-utils directory
-  file:
+  ansible.builtin.file:
     mode: 0755
     path: /tmp/efs-utils
     state: directory
 
 - name: Download a tarball of the aws/efs-utils repository
-  unarchive:
+  ansible.builtin.unarchive:
     src: https://github.com/aws/efs-utils/tarball/master
     dest: /tmp/efs-utils
     remote_src: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for amazon-efs-utils
 
 - name: Load tasks file with install tasks based on the OS type
-  include: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
@@ -13,6 +13,6 @@
         - "{{ role_path }}/tasks"
 
 - name: Enable Amazon EFS mount watchdog service
-  service:
+  ansible.builtin.service:
     name: amazon-efs-mount-watchdog
     enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,3 +16,9 @@
   ansible.builtin.service:
     name: amazon-efs-mount-watchdog
     enabled: yes
+
+- name: Create a group for EFS share users
+  ansible.builtin.group:
+    gid: "{{ efs_users_gid | default(omit) }}"
+    name: "{{ efs_users_group }}"
+  when: create_efs_users_group


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds an option to create a group for EFS users and, if desired, specify its GID.

## 💭 Motivation and context ##

I want to create such a group in order to make it easier for the VNC users and the Samba guest user to work with the EFS share.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [ ] _All_ future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
