### PR TITLE
Add OpenSSL development package for Debian

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -22,7 +22,14 @@ def test_packages(host):
         if codename in ["buster", "bullseye", "bookworm"]:
             pkgs = ["amazon-efs-utils", "binutils", "make"]
         else:
-            pkgs = ["amazon-efs-utils", "binutils", "cargo", "make", "pkgconf"]
+            pkgs = [
+                "amazon-efs-utils",
+                "binutils",
+                "cargo",
+                "libssl-dev",
+                "make",
+                "pkgconf",
+            ]
     elif distribution in ["amzn"]:
         pkgs = ["amazon-efs-utils"]
     else:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,4 +8,4 @@ package_names:
   - pkgconf
 
 # The version of amazon-efs-utils to install.
-version: 2.0.0
+version: 2.0.1

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,6 +3,7 @@
 package_names:
   - binutils
   - cargo
+  - libssl-dev
   - make
   - pkgconf
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,4 +7,4 @@ package_names:
   - rpm-build
 
 # The version of amazon-efs-utils to install.
-version: 2.0.0
+version: 2.0.1


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Adds the `libssl-dev` package as a prerequisite when installing on a Debian-based platform.
- Upgrades to version 2.0.1 of [aws/efs-utils](https://github.com/aws/efs-utils) for RedHat and recent Debian releases.

## 💭 Motivation and context ##

- The `molecule` tests pass without this change, but when building a Kali AMI in [cisagov/kali-packer](https://github.com/cisagov/kali-packer) I found that [the package was missing](https://github.com/cisagov/kali-packer/actions/runs/9070834175/job/24923502424?pr=170#step:16:151).
- We may as well upgrade to the latest code while we're here.  (There is no newer 1.x package available.)

## 🧪 Testing ##

All automated tests pass.  I also ran another Kali AMI build with this change and found that it now [successfully installs this Ansible role](https://github.com/cisagov/kali-packer/actions/runs/9081814852/job/24958540981?pr=170#step:16:131).

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.