### PR TITLE
Use 1.x version of aws/efs-utils on Ubuntu Jammy

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -19,6 +19,8 @@ def test_packages(host):
     if distribution in ["fedora"]:
         pkgs = ["amazon-efs-utils", "cargo", "make", "openssl-devel", "rpm-build"]
     elif distribution in ["debian", "kali", "ubuntu"]:
+        # TODO - Install version 2.x on Ubuntu Jammy when possible.
+        # See #53 for more details.
         if codename in ["buster", "bullseye", "bookworm", "jammy"]:
             pkgs = ["amazon-efs-utils", "binutils", "make"]
         else:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -19,7 +19,7 @@ def test_packages(host):
     if distribution in ["fedora"]:
         pkgs = ["amazon-efs-utils", "cargo", "make", "openssl-devel", "rpm-build"]
     elif distribution in ["debian", "kali", "ubuntu"]:
-        if codename in ["buster", "bullseye", "bookworm"]:
+        if codename in ["buster", "bullseye", "bookworm", "jammy"]:
             pkgs = ["amazon-efs-utils", "binutils", "make"]
         else:
             pkgs = [

--- a/vars/Ubuntu_jammy.yml
+++ b/vars/Ubuntu_jammy.yml
@@ -1,0 +1,1 @@
+Debian_bookworm.yml


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the role to use the 1.x version of [aws/efs-utils](https://github.com/aws/efs-utils) on Ubuntu Jammy.

## 💭 Motivation and context ##

The Molecule tests pass when we use version 2.x of [aws/efs-utils](https://github.com/aws/efs-utils) on Ubuntu Jammy platform, but when building an actual AMI the installation of `cargo` pulls in the `libssh2-1` package, which seems to break the running `ssh` server.  See [this build](https://github.com/cisagov/ubuntu-server-packer/actions/runs/9226352690/job/25386015270?pr=24), for example.

On Ubuntu Noble the installation of `cargo` instead pulls in the `libssh2-1t64` package, which hopefully will not break the running ssh server.

## 🧪 Testing ##

All automated tests pass.  I was also able to successfully build a [cisagov/ubuntu-server-packer](https://github.com/cisagov/ubuntu-server-packer) AMI with this change.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.