### PR TITLE
Upgrade to version 2.0.2 where possible

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,4 +8,4 @@ package_names:
   - pkgconf
 
 # The version of amazon-efs-utils to install.
-version: 2.0.1
+version: 2.0.2

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,4 +7,4 @@ package_names:
   - rpm-build
 
 # The version of amazon-efs-utils to install.
-version: 2.0.1
+version: 2.0.2


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades all platforms that support [aws/efs-utils](https://github.com/aws/efs-utils) version 2.x to use version 2.0.2.

## 💭 Motivation and context ##

This new 2.x version was [just released](https://github.com/aws/efs-utils/releases/tag/v2.0.2).  It features [some changes that allow aws/efs-utils to do a better job of cleaning up after itself](https://github.com/aws/efs-utils/pull/219/files).  It's also generally good to stay current.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.