### PR TITLE
Use old version on Ubuntu Noble

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -19,9 +19,9 @@ def test_packages(host):
     if distribution in ["fedora"]:
         pkgs = ["amazon-efs-utils", "cargo", "make", "openssl-devel", "rpm-build"]
     elif distribution in ["debian", "kali", "ubuntu"]:
-        # TODO - Install version 2.x on Ubuntu Jammy when possible.
-        # See #53 for more details.
-        if codename in ["buster", "bullseye", "bookworm", "jammy"]:
+        # TODO - Install version 2.x on Ubuntu Jammy and Noble when
+        # possible.  See #53 for more details.
+        if codename in ["buster", "bullseye", "bookworm", "jammy", "noble"]:
             pkgs = ["amazon-efs-utils", "binutils", "make"]
         else:
             pkgs = [

--- a/vars/Ubuntu_noble.yml
+++ b/vars/Ubuntu_noble.yml
@@ -1,0 +1,1 @@
+Debian_bookworm.yml


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the role to install the 1.x version of [aws/efs-utils](https://github.com/aws/efs-utils) on Ubuntu Noble.

## 💭 Motivation and context ##

Version 2.x pulls in a package that breaks the running `ssh` server.  See #53 for more details.

## 🧪 Testing ##

All automated tests pass.  I also built a Ubuntu Noble staging AMI with these changes as part of cisagov/ubuntu-server-packer#27 and verified that it functioned as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.