### PR TITLE
Upgrade to version 2.0.3 wherever posssible

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,4 +8,4 @@ package_names:
   - pkgconf
 
 # The version of amazon-efs-utils to install.
-version: 2.0.2
+version: 2.0.3

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,4 +7,4 @@ package_names:
   - rpm-build
 
 # The version of amazon-efs-utils to install.
-version: 2.0.2
+version: 2.0.3


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades to version 2.0.3 of [aws/efs-utils](https://github.com/aws/efs-utils) wherever possible.

## 💭 Motivation and context ##

We should stay current.  Resolves #55.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.