### PR TITLE
Upgrade to version 2.2.0 where possible

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,6 +3,7 @@
 package_names:
   - binutils
   - cargo
+  - gettext-base
   - libssl-dev
   - make
   - pkgconf

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,4 +8,4 @@ package_names:
   - pkgconf
 
 # The version of amazon-efs-utils to install.
-version: 2.1.0
+version: 2.2.0

--- a/vars/Debian_bookworm.yml
+++ b/vars/Debian_bookworm.yml
@@ -5,4 +5,7 @@ package_names:
   - make
 
 # The version of amazon-efs-utils to install.
+#
+# Debian Bookworm has too old a version of the Cargo/Rust toolchain to
+# build version >=2.
 version: 1.36.0

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -2,6 +2,7 @@
 # The system packages to install.
 package_names:
   - cargo
+  - gettext-envsubst
   - make
   - openssl-devel
   - openssl-devel-engine

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -8,4 +8,4 @@ package_names:
   - rpm-build
 
 # The version of amazon-efs-utils to install.
-version: 2.1.0
+version: 2.2.0

--- a/vars/Fedora_39.yml
+++ b/vars/Fedora_39.yml
@@ -7,4 +7,4 @@ package_names:
   - rpm-build
 
 # The version of amazon-efs-utils to install.
-version: 2.1.0
+version: 2.2.0

--- a/vars/Fedora_39.yml
+++ b/vars/Fedora_39.yml
@@ -2,6 +2,7 @@
 # The system packages to install.
 package_names:
   - cargo
+  - gettext-envsubst
   - make
   - openssl-devel
   - rpm-build

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,4 +7,4 @@ package_names:
   - rpm-build
 
 # The version of amazon-efs-utils to install.
-version: 2.1.0
+version: 2.2.0

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,6 +2,7 @@
 # The system packages to install.
 package_names:
   - cargo
+  - gettext-envsubst
   - make
   - openssl-devel
   - rpm-build

--- a/vars/Ubuntu_jammy.yml
+++ b/vars/Ubuntu_jammy.yml
@@ -1,0 +1,1 @@
+Debian_bookworm.yml

--- a/vars/Ubuntu_noble.yml
+++ b/vars/Ubuntu_noble.yml
@@ -1,0 +1,1 @@
+Debian_bookworm.yml


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Upgrades to version 2.2.0 of [aws/efs-utils](https://github.com/aws/efs-utils) where possible
- Reverts the change made in #57 that upgraded Ubuntu platforms to version 2.x of [aws/efs-utils](https://github.com/aws/efs-utils)

## 💭 Motivation and context ##

- It is good to stay current.
- The Molecule tests pass with the change in #57, but building an actual AMI with these changes fails for the reasons stated in issue #53.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.